### PR TITLE
Simplify gapindex search logic.

### DIFF
--- a/FlexCore.py
+++ b/FlexCore.py
@@ -75,14 +75,8 @@ def get_pw_snps(pairs, coreseqindex):
         # get sites missing in either seq of pair
         gapindex = list(
             set(
-                [i for i, e in enumerate(g1seqlist) if e == "-"]
-                + [i for i, e in enumerate(g2seqlist) if e == "-"]
-            )
-        )
-        gapindex += list(
-            set(
-                [i for i, e in enumerate(g1seqlist) if e == "N"]
-                + [i for i, e in enumerate(g2seqlist) if e == "N"]
+                [i for i, e in enumerate(g1seqlist) if e in ("-", "N")]
+                + [i for i, e in enumerate(g2seqlist) if e in ("-", "N")]
             )
         )
 


### PR DESCRIPTION
Previous logic may include duplicate entries where g1 is '-' and g2 'N' or vice versa.